### PR TITLE
output database IP

### DIFF
--- a/database.tf
+++ b/database.tf
@@ -16,7 +16,7 @@ resource "scaleway_rdb_instance" "main" {
   node_type                 = var.database_node_type
   engine                    = var.database_engine
   is_ha_cluster             = var.database_highly_available
-  user_name                 = random_uuid.db_username.result
+  user_name                 = "uuid-${random_uuid.db_username.result}"
   password                  = random_password.db_password.result
   volume_type               = "bssd"
   volume_size_in_gb         = var.database_storage_size_gb

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
+output "database_id" {
+  value = scaleway_rdb_instance.main.id
+}
+
 output "database_load_balancer" {
   value = scaleway_rdb_instance.main.load_balancer
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,5 +15,5 @@ output "database_private_network" {
 }
 
 output "database_user_name" {
-  value = random_uuid.db_username.result
+  value = "uuid-${random_uuid.db_username.result}"
 }


### PR DESCRIPTION
- adds `database_id` as an output of the module
- prepending database usernames with `uuid-` because UUIDs sometimes didn't start with a letter and caused the error:

```
scaleway_rdb_instance.main: Creating...
╷
│ Error: scaleway-sdk-go: invalid argument(s): user_name does not respect constraint, the first character of the user_name must be a letter
```