### PR TITLE
allow dynamic settings

### DIFF
--- a/database.tf
+++ b/database.tf
@@ -1,11 +1,3 @@
-locals {
-  rdb_settings = merge(
-    var.database_max_connections != null ? { "max_connections" = var.database_max_connections } : {},
-    var.database_statement_timeout != null ? { "statement_timeout" = var.database_statement_timeout } : {},
-    var.database_idle_in_transaction_session_timeout != null ? { "idle_in_transaction_session_timeout" = var.database_idle_in_transaction_session_timeout } : {},
-  )
-}
-
 resource "random_uuid" "db_username" {
 }
 
@@ -36,7 +28,7 @@ resource "scaleway_rdb_instance" "main" {
     pn_id = var.private_network_id
   }
 
-  settings = local.rdb_settings
+  settings = var.database_settings
 }
 
 resource "scaleway_rdb_acl" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -22,27 +22,12 @@ variable "database_storage_size_gb" {
   default     = "10"
 }
 
-variable "database_max_connections" {
-  description = "Scaleway RDB max_connections. Omit (null) to leave the engine default."
-  type        = string
-  default     = null
-  nullable    = true
-}
-
-# Optional advanced PostgreSQL settings (Scaleway RDB). Omit (null) to leave the engine default.
-# For timeouts, Scaleway expects milliseconds as a string integer (e.g. 600000 for 10m), not interval strings like 10m.
-variable "database_statement_timeout" {
-  description = "Postgres statement_timeout. Scaleway: string integer, milliseconds (e.g. 600000 = 10m)."
-  type        = string
-  default     = null
-  nullable    = true
-}
-
-variable "database_idle_in_transaction_session_timeout" {
-  description = "Postgres idle_in_transaction_session_timeout. Scaleway: string integer, milliseconds (e.g. 300000 = 5m)."
-  type        = string
-  default     = null
-  nullable    = true
+# Optional Scaleway RDB engine settings (PostgreSQL parameter names to values). Empty {} keeps engine defaults.
+# Values are strings as required by the API (e.g. max_connections = "100"; timeouts often as milliseconds like "600000").
+variable "database_settings" {
+  description = "Map of Scaleway RDB setting names to values."
+  type        = map(string)
+  default     = {}
 }
 
 variable "database_name" {


### PR DESCRIPTION
Derive database settings entirely from the map provided to the module, eg:

```
  database_settings = {
    effective_cache_size                = "6144"
    idle_in_transaction_session_timeout = "120000"
    maintenance_work_mem                = "512"
    max_connections                     = "1000"
    max_parallel_workers                = "3"
    max_parallel_workers_per_gather     = "2"
    statement_timeout                   = "120000"
    work_mem                            = "8"
  }
```